### PR TITLE
Expand ProgressListener

### DIFF
--- a/src/main/java/org/parabot/api/io/ProgressListener.java
+++ b/src/main/java/org/parabot/api/io/ProgressListener.java
@@ -12,13 +12,33 @@ public interface ProgressListener {
      *
      * @param value
      */
-    public void onProgressUpdate(double value);
+    void onProgressUpdate(double value);
 
     /**
      * Updates upload speed
      *
      * @param mbPerSecond
      */
-    public void updateDownloadSpeed(double mbPerSecond);
+    void updateDownloadSpeed(double mbPerSecond);
+
+    /**
+     * Sets the message displayed
+     * @param message The Text to show
+     */
+    void updateMessage(String message);
+
+    /**
+     * Combination of the two
+     * @param message
+     * @param progress
+     */
+    void updateMessageAndProgress(String message, double progress);
+
+    /**
+     * Usage would be
+     * <pre>double before = getCurrentProgress() <br> setCurrent(0) <br> for 0 .. 100: setCurrent(x) <br> done! <br> setCurrent(before)</pre>
+     * @return
+     */
+    double getCurrentProgress();
 
 }


### PR DESCRIPTION
Previously usage was limited to 
`void onProgressUpdate(double value);`
which displays a "xMB/s" message and doesn't change the underlying value of the progress bar.

This PR allows the text and value to be set, so you can go from 0-100% and display a "xMB/s" message as usual.

![alt](https://i.imgur.com/zvwAY9D.jpg)